### PR TITLE
Employ ABO theory in MOOG

### DIFF
--- a/oracle/solvers/synthesise.py
+++ b/oracle/solvers/synthesise.py
@@ -193,7 +193,7 @@ if __name__ == "__main__":
         "species": 26.0,
         "excitation_potential": 2.727,
         "loggf": -1.473,
-        "C6": 320.26400756
+        "VDW_DAMP": 320.26400756
     }])
 
     import cPickle as pickle
@@ -207,7 +207,14 @@ if __name__ == "__main__":
     #wavelength_range = [6592.9124 - 5., 6597.2]
     
     synthesiser = lambda abundance: oracle.synthesis.moog.synthesise(transitions,
-        photosphere, wavelength_range, microturbulence=1.07, photospheric_abundances=[26, abundance])
+        photosphere, wavelength_range, microturbulence=1.07,
+        photospheric_abundances=[26, abundance], damping=4)
+
+    # 0 = 840699499.20031548
+    # 1 = 111950631.80524081
+    # 2 = 126757416.63107705
+    # 3 = 1231810711.2760828
+    # 4 = 116284148.07045062
 
 
     foo = SynthesisFitter(radial_velocity_tolerance=3, continuum_degree=0)

--- a/oracle/synthesis/moog.py
+++ b/oracle/synthesis/moog.py
@@ -46,7 +46,7 @@ def _format_transitions(transitions):
         "excitation_potential",
         "loggf",
         #"C1", # RADIATION DAMPING
-        "C6", # Van Der Waals DAMPING
+        "VDW_DAMP", # Coefficient for collisional broadening by Hydrogen (vdW)
         "D0", # Dissociation energy [eV]
         #"C4", # GAMMA, QUADRATIC STARK DAMPING
         "equivalent_width")
@@ -253,6 +253,7 @@ def synthesise(transitions, photosphere_information, wavelength_region=None,
         raise ValueError("opacity contribution must be a positive float")
 
     debug = kwargs.pop("debug", False)
+    damping = kwargs.pop("damping", 4)
     modtype, photosphere_arr, metallicity = _format_photosphere(
         photosphere_information, photosphere_kwargs,
         interpolator=kwargs.pop("_interpolator", None))
@@ -288,6 +289,7 @@ def synthesise(transitions, photosphere_information, wavelength_region=None,
         photosphere_arr, photospheric_abundances, transitions, synthesis_region,
         opacity_contribution, in_npoints=pixels, in_modtype=modtype,
         in_debug=debug, #f2pystop=MOOGException(),
+        damping=damping,
         data_path=os.path.dirname(__file__))
 
     assert wavelengths.size == fluxes.size
@@ -346,6 +348,8 @@ def atomic_abundances(transitions, photosphere_information, microturbulence,
         photosphere_information, photosphere_kwargs,
         interpolator=kwargs.pop("_interpolator", None))
 
+    damping = kwargs.pop("damping", 4)
+
     # Prepare the transitions table.
     transitions = _format_transitions(transitions)
     
@@ -357,7 +361,7 @@ def atomic_abundances(transitions, photosphere_information, microturbulence,
         code, output = moog.abundances(metallicity, microturbulence,
             photosphere_arr, photospheric_abundances, transitions,
             in_modtype=modtype, in_debug=debug, f2pystop=MOOGException(),
-            data_path=os.path.dirname(__file__))
+            damping=damping, data_path=os.path.dirname(__file__))
         return output
 
     else:

--- a/oracle/synthesis/source/moog/MyAbfind.f
+++ b/oracle/synthesis/source/moog/MyAbfind.f
@@ -1,7 +1,7 @@
 
       function abundances(in_metallicity, in_xi,
      .   in_photosphere, in_logepsilon_abundances,
-     .   in_transitions, in_modtype, in_debug, output,
+     .   in_transitions, in_modtype, damping, in_debug, output,
      .   data_path, in_ntau, in_ncols, in_natoms, in_nlines)
 
       implicit real*8 (a-h,o-z)
@@ -12,6 +12,7 @@
      .   in_logepsilon_abundances
       real*8, dimension(in_nlines, 7), intent(in) :: in_transitions
       character*10, intent(in) :: in_modtype
+      integer :: damping
       integer, optional :: in_debug
       character(300), intent(in) :: data_path
 
@@ -43,7 +44,7 @@ c     Params crap. Can probably be removed eventually.
       linprintopt  = 2
       fluxintopt   = 0
       plotopt      = 0
-      dampingopt   = 3
+      dampingopt   = 0 + damping
       specfileopt  = 0
       linfileopt   = 0
       iunits       = 0

--- a/oracle/synthesis/source/moog/MySynth.f
+++ b/oracle/synthesis/source/moog/MySynth.f
@@ -2,7 +2,7 @@
       function synthesise(in_metallicity, in_xi,
      .   in_photosphere, in_logepsilon_abundances,
      .   in_transitions, in_synlimits, in_opacity_contributes, 
-     .   in_npoints, in_modtype, in_debug, wavelengths, fluxes,
+     .   in_modtype, damping, in_npoints, in_debug, wavelengths, fluxes,
      .   data_path, in_ntau, in_ncols, in_natoms, in_nlines)
 
       implicit real*8 (a-h,o-z)
@@ -14,7 +14,7 @@
       real*8, dimension(in_nlines, 7), intent(in) :: in_transitions
       real*8, dimension(3) :: in_synlimits
       real*8, intent(in) :: in_opacity_contributes 
-      integer :: in_npoints
+      integer :: damping, in_npoints
       character*10, intent(in) :: in_modtype
       integer, optional :: in_debug
       character(300), intent(in) :: data_path
@@ -49,7 +49,7 @@
       linprintopt  = 2
       fluxintopt   = 0
       plotopt      = 0
-      dampingopt   = 3
+      dampingopt   = 0 + damping
       specfileopt  = 0
       linfileopt   = 0
       iunits       = 0


### PR DESCRIPTION
This pull request implements ABO broadening theory in the C-wrapped Python `Oracle` version of MOOG.

A new damping option `damping=4` will employ ABO theory if the `VDW_DAMP` coefficient for a line is greater than 20. For values lower than 20, the `damping=2` option is followed in MOOG. The  recommended `int(sigma).alpha` format is followed.

/cc @martinasplund
